### PR TITLE
Fixed critical typo, Raycasting improvements

### DIFF
--- a/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
+++ b/src/main/java/com/sonicether/soundphysics/SoundPhysics.java
@@ -395,10 +395,10 @@ public class SoundPhysics
 
 		for (int i = 0; i < numRays; i++)
 		{
-			final float x = (float) (i + epsilon) / (numRays - 1.0 + 2.0*epsilon);
+			final float x = (float) ((float) (i + epsilon) / (numRays - 1.0 + 2.0*epsilon));
 			final float y = (float) i / gRatio;
-			final float theta = 2.0f * Math.PI * y;
-			final float phi = Math.acos(1.0f - 2.0f*x);
+			final float theta = (float) (2.0f * Math.PI * y);
+			final float phi = (float) Math.acos(1.0f - 2.0f*x);
 			//final double theta = 2.0 * Math.PI * rand.nextDouble();
 			//final double phi = Math.acos(1.0f - 2.0f * rand.nextDouble());
 			


### PR DESCRIPTION
Fixed a critical typo causing both the ray count and ray bounce count to be set to the config file's ray count value

Changed the raycast distribution from a golden spiral to the more effective offset Fibonacci lattice. (see http://extremelearning.com.au/how-to-evenly-distribute-points-on-a-sphere-more-effectively-than-the-canonical-fibonacci-lattice/) This should improve render performance by ensuring an even distribution of rays.