### PR TITLE
Translate `enum` values

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ minecraft_version=1.18
 yarn_mappings=1.18+build.1
 loader_version=0.12.5
 # Mod Properties
-mod_version=3.2
+mod_version=4.1
 maven_group=com.soniether
 archives_base_name=soundphysics
 # Dependencies

--- a/src/main/java/com/sonicether/soundphysics/config/ConfigManager.java
+++ b/src/main/java/com/sonicether/soundphysics/config/ConfigManager.java
@@ -28,7 +28,7 @@ public class ConfigManager {
         holder = AutoConfig.register(SoundPhysicsConfig.class, JanksonConfigSerializer::new);
         holder.load();
         if (holder.getConfig().Material_Properties.reflectivityMap == null) {
-            holder.getConfig().preset = ConfigPresets.DrRubisco_Signature;
+            holder.getConfig().preset = ConfigPresets.THEDOCRUBY;
             holder.getConfig().Material_Properties.reflectivityMap = DEFAULT.Material_Properties.reflectivityMap;
         }
         reload(false);

--- a/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
+++ b/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
@@ -85,7 +85,7 @@ public enum ConfigPresets {
 
             null, null, null,null, null, null
     )),
-    LOAD_SUCCESS("Custom", null);
+    LOAD_SUCCESS("Choose", null);
 
 
 

--- a/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
+++ b/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
@@ -9,11 +9,9 @@ import java.lang.String;
 
 import static com.sonicether.soundphysics.config.ConfigChanger.changeConfig;
 
-import net.minecraft.network.chat.TranslatableComponent;
-
 @SuppressWarnings("unused")
 public enum ConfigPresets {
-    DEFAULT("DEFAULT", (SoundPhysicsConfig c) -> changeConfig(c, true,
+    DEFAULT("Default", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             1.0, 1.0, 1.0, 1.0,
             1.0, 4.0, 1.0, 0.8,
@@ -26,7 +24,7 @@ public enum ConfigPresets {
 
             0.15, 10.0, true, true, 0.5, true
     )),
-    THEDOCRUBY("THEDOCRUBY", (SoundPhysicsConfig c) -> changeConfig(c, true,
+    THEDOCRUBY("Dr. Rubisco's Signature Sound", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             1.0, 0.8, 1.0, 0.8,
             1.0, 3.0, 1.0, 1.0,
@@ -63,7 +61,7 @@ public enum ConfigPresets {
             0.5, 10.0, true, true, 0.1, false
 
     )),
-    SP1_0_SOUND_OCCLUSION("SP1_0_SOUND_OCCLUSION", (SoundPhysicsConfig c) -> changeConfig(c, true,
+    SP1_0_SOUND_OCCLUSION("Total Occlusion", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             null, null, null, 10.0,
             null, null, null, null,
@@ -74,7 +72,7 @@ public enum ConfigPresets {
 
             null, 10.0, null, null, null, null
     )),
-    RESET_MATERIALS("RESET_MATERIALS", (SoundPhysicsConfig c) -> changeConfig(c, true,
+    RESET_MATERIALS("Reset Material Properties", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             null, null, null, null,
             null, null, null, null,
@@ -87,22 +85,22 @@ public enum ConfigPresets {
 
             null, null, null,null, null, null
     )),
-    LOAD_SUCCESS("LOAD_SUCCESS", null);
+    LOAD_SUCCESS("Custom", null);
 
 
 
 
     public final Consumer<SoundPhysicsConfig> configChanger;
-    public TranslatableComponent component;
+    public final String text;
     public void setConfig(){ if (configChanger != null) configChanger.accept(ConfigManager.getConfig());}
 
-    ConfigPresets(String value, @Nullable Consumer<SoundPhysicsConfig> c) { 
+    ConfigPresets(String text, @Nullable Consumer<SoundPhysicsConfig> c) {
         this.configChanger = c; 
-        this.component = new TranslatableComponent("text.autoconfig.sound_physics.option.preset.value." + value);
+        this.text = text;
     }
 
     @Override
     public String toString() {
-        return this.component.toString();
+        return this.text;
     }
 }

--- a/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
+++ b/src/main/java/com/sonicether/soundphysics/config/ConfigPresets.java
@@ -3,15 +3,17 @@ package com.sonicether.soundphysics.config;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import static java.util.Map.entry;
 import java.util.function.Consumer;
+import java.lang.String;
 
 import static com.sonicether.soundphysics.config.ConfigChanger.changeConfig;
-import static java.util.Map.entry;
+
+import net.minecraft.network.chat.TranslatableComponent;
 
 @SuppressWarnings("unused")
 public enum ConfigPresets {
-    LOAD_SUCCESS(null),
-    DEFAULT((SoundPhysicsConfig c) -> changeConfig(c, true,
+    DEFAULT("DEFAULT", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             1.0, 1.0, 1.0, 1.0,
             1.0, 4.0, 1.0, 0.8,
@@ -24,31 +26,7 @@ public enum ConfigPresets {
 
             0.15, 10.0, true, true, 0.5, true
     )),
-    RESET_MATERIALS((SoundPhysicsConfig c) -> changeConfig(c, true,
-
-            null, null, null, null,
-            null, null, null, null,
-
-            null, null, null, null,
-
-            Map.ofEntries(entry(".DEFAULT", 0.5), entry("STONE", 1.0), entry("WOOD", 0.4), entry("GRAVEL", 0.3),
-            entry("GRASS", 0.5), entry("METAL", 1.0), entry("GLASS", 0.5), entry("WOOL", 0.05),
-            entry("SAND", 0.2), entry("SNOW", 0.2), entry("LADDER", 0.4), entry("ANVIL", 1.0)),
-
-            null, null, null,null, null, null
-    )),
-    SP1_0_SOUND_OCCLUSION((SoundPhysicsConfig c) -> changeConfig(c, true,
-
-            null, null, null, 10.0,
-            null, null, null, null,
-
-            null, null, null, null,
-
-            null,
-
-            null, 10.0, null, null, null, null
-    )),
-    DrRubisco_Signature((SoundPhysicsConfig c) -> changeConfig(c, true,
+    THEDOCRUBY("THEDOCRUBY", (SoundPhysicsConfig c) -> changeConfig(c, true,
 
             1.0, 0.8, 1.0, 0.8,
             1.0, 3.0, 1.0, 1.0,
@@ -84,15 +62,47 @@ public enum ConfigPresets {
 
             0.5, 10.0, true, true, 0.1, false
 
-    ));
+    )),
+    SP1_0_SOUND_OCCLUSION("SP1_0_SOUND_OCCLUSION", (SoundPhysicsConfig c) -> changeConfig(c, true,
+
+            null, null, null, 10.0,
+            null, null, null, null,
+
+            null, null, null, null,
+
+            null,
+
+            null, 10.0, null, null, null, null
+    )),
+    RESET_MATERIALS("RESET_MATERIALS", (SoundPhysicsConfig c) -> changeConfig(c, true,
+
+            null, null, null, null,
+            null, null, null, null,
+
+            null, null, null, null,
+
+            Map.ofEntries(entry(".DEFAULT", 0.5), entry("STONE", 1.0), entry("WOOD", 0.4), entry("GRAVEL", 0.3),
+            entry("GRASS", 0.5), entry("METAL", 1.0), entry("GLASS", 0.5), entry("WOOL", 0.05),
+            entry("SAND", 0.2), entry("SNOW", 0.2), entry("LADDER", 0.4), entry("ANVIL", 1.0)),
+
+            null, null, null,null, null, null
+    )),
+    LOAD_SUCCESS("LOAD_SUCCESS", null);
 
 
 
 
     public final Consumer<SoundPhysicsConfig> configChanger;
+    public TranslatableComponent component;
     public void setConfig(){ if (configChanger != null) configChanger.accept(ConfigManager.getConfig());}
 
-    ConfigPresets(@Nullable Consumer<SoundPhysicsConfig> c) { this.configChanger = c; }
+    ConfigPresets(String value, @Nullable Consumer<SoundPhysicsConfig> c) { 
+        this.configChanger = c; 
+        this.component = new TranslatableComponent("text.autoconfig.sound_physics.option.preset.value." + value);
+    }
 
-
+    @Override
+    public String toString() {
+        return this.component.toString();
+    }
 }

--- a/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
+++ b/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
@@ -99,6 +99,6 @@ public class SoundPhysicsConfig implements ConfigData {
     }
 
     @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
-    @Comment("Soft presets (preserve some settings). Set \"Config has changed\" to true before saving!)
+    @Comment("Soft presets (preserve some settings). Set \"Config has changed\" to true before saving!")
     public ConfigPresets preset = ConfigPresets.LOAD_SUCCESS;
 }

--- a/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
+++ b/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
@@ -98,7 +98,7 @@ public class SoundPhysicsConfig implements ConfigData {
         public boolean raytraceParticles = false;
     }
 
-    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
+    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.DROPDOWN)
     @Comment("Soft presets (preserve some settings). Set \"Config has changed\" to true before saving!")
     public ConfigPresets preset = ConfigPresets.LOAD_SUCCESS;
 }

--- a/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
+++ b/src/main/java/com/sonicether/soundphysics/config/SoundPhysicsConfig.java
@@ -98,7 +98,7 @@ public class SoundPhysicsConfig implements ConfigData {
         public boolean raytraceParticles = false;
     }
 
-    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.DROPDOWN)
-    @Comment("Soft presets (preserve some settings). Set \"Config has changed\" to true before saving.\nPresets: [DEFAULT, DrRubisco_Signature, SP1_0_SOUND_OCCLUSION]\nLOAD_SUCCESS is used for loading any saved config not defined by a preset.\nRESET_MATERIALS is for reseting material reflectance not changed by a soft config.")
+    @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
+    @Comment("Soft presets (preserve some settings). Set \"Config has changed\" to true before saving!)
     public ConfigPresets preset = ConfigPresets.LOAD_SUCCESS;
 }

--- a/src/main/resources/assets/soundphysics/lang/en_us.json
+++ b/src/main/resources/assets/soundphysics/lang/en_us.json
@@ -39,5 +39,10 @@
   "text.autoconfig.sound_physics.option.Misc.performanceLogging": "Performance logging",
   "text.autoconfig.sound_physics.option.Misc.raytraceParticles": "Raytracing Particles",
 
-  "text.autoconfig.sound_physics.option.preset": "Preset"
+  "text.autoconfig.sound_physics.option.preset": "Preset",
+  "text.autoconfig.sound_physics.option.preset.value.DEFAULT": "Default",
+  "text.autoconfig.sound_physics.option.preset.value.LOAD_SUCCESS": "Custom",
+  "text.autoconfig.sound_physics.option.preset.value.RESET_MATERIALS": "Reset Material Properties",
+  "text.autoconfig.sound_physics.option.preset.value.SP1_0_SOUND_OCCLUSION": "Total Occlusion",
+  "text.autoconfig.sound_physics.option.preset.value.THEDOCRUBY": "Dr. Rubisco's Signature Sound"
 }

--- a/src/main/resources/assets/soundphysics/lang/en_us.json
+++ b/src/main/resources/assets/soundphysics/lang/en_us.json
@@ -39,5 +39,5 @@
   "text.autoconfig.sound_physics.option.Misc.performanceLogging": "Performance logging",
   "text.autoconfig.sound_physics.option.Misc.raytraceParticles": "Raytracing Particles",
 
-  "text.autoconfig.sound_physics.option.preset": "Preset",
+  "text.autoconfig.sound_physics.option.preset": "Preset"
 }

--- a/src/main/resources/assets/soundphysics/lang/en_us.json
+++ b/src/main/resources/assets/soundphysics/lang/en_us.json
@@ -40,9 +40,4 @@
   "text.autoconfig.sound_physics.option.Misc.raytraceParticles": "Raytracing Particles",
 
   "text.autoconfig.sound_physics.option.preset": "Preset",
-  "text.autoconfig.sound_physics.option.preset.value.DEFAULT": "Default",
-  "text.autoconfig.sound_physics.option.preset.value.LOAD_SUCCESS": "Custom",
-  "text.autoconfig.sound_physics.option.preset.value.RESET_MATERIALS": "Reset Material Properties",
-  "text.autoconfig.sound_physics.option.preset.value.SP1_0_SOUND_OCCLUSION": "Total Occlusion",
-  "text.autoconfig.sound_physics.option.preset.value.THEDOCRUBY": "Dr. Rubisco's Signature Sound"
 }


### PR DESCRIPTION
This PR aims to do a number of things to improve the config:
- [x] Add translations for the `enum` values in lang file
- [ ] Add translatable tooltips to the config screen
- [ ] Add more basic presets with different purposes
- [ ] Remove the need for `reloadReverb` using the config save event in cloth configthat I read about yesterday and can't seem to find any documentation about it today (including where I originally read it)

I also submitted a request for shedaniel to add the ability for us to access the traditional style of drop-down menu from the Auto Config API, it is not currently accessible to us even though it is part of Cloth Config. This will be much better than the current style of "suggestive search" dropdown, and will remove the need for all of the presets to be listed in the tooltip. I also requested her to enable the dropdowns to change width based on the width of their content, which is something that other configs do and is very useful. Also, about the cloth config file save event that I read about yesterday? I can't seem to find any documentation about it anywhere (including where I originally read about it).

EDIT: After nearly 2.5 hours of searching, I still can't find the documentation for the cloth config file save event, or a lot of other things. Come to think of it, i only knew that the dropdowns even existed in Auto Config because they were already in this mod, since there is zero documentation about them in the wiki. Cloth Config is looking more and more like a very poorly maintained and documented API, which is very frustrating. I'm starting to think it might be a better idea to use something like SpruceUI, or just try to make our own config screen like Iris is doing.